### PR TITLE
problem in gulpfile.js with concat task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,6 +40,6 @@ gulp.task('clean', function(cb) {
 gulp.task('default', function(cb) {
   runSequence('clean',
       'build:ng2',
-      'concat',
+      'build:shim',
       cb);
 });


### PR DESCRIPTION
fixed an error where the concat task was called by the default task, but should call build:shim instead.

run-sequence was complaining that concat (from line 43 in the gulpfile) wasn't a task. Looking at the file, the concat call is in build:shim so I'm assuming that's the desired task to call. Maybe it should be a new "concat" task?  If it should be something else let me know and I'll adjust the PR.